### PR TITLE
edit README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
-[![Build Status](https://travis-ci.org/treasure-data/embulk-input-marketo.svg?branch=master)](https://travis-ci.org/treasure-data/embulk-input-marketo)
-[![Code Climate](https://codeclimate.com/github/treasure-data/embulk-input-marketo/badges/gpa.svg)](https://codeclimate.com/github/treasure-data/embulk-input-marketo)
-[![Test Coverage](https://codeclimate.com/github/treasure-data/embulk-input-marketo/badges/coverage.svg)](https://codeclimate.com/github/treasure-data/embulk-input-marketo/coverage)
-[![Gem Version](https://badge.fury.io/rb/embulk-input-marketo.svg)](http://badge.fury.io/rb/embulk-input-marketo)
+# Marketo input plugin for Embulk (through proxy)
 
-# Marketo input plugin for Embulk
+* This plugin is an extension of [embulk-input-marketo](https://rubygems.org/gems/embulk-input-marketo) that allows you to access Marketo API through a proxy server.
 
 embulk-input-marketo is the gem preparing Embulk input plugins for [Marketo](http://www.marketo.com/).
 
@@ -229,3 +226,10 @@ in:
   incremental: true
   ```
 
+If you need to access the Marketo API through a proxy, set the environment variable.
+
+```
+export embulk_proxy_host=<Your-Proxy-Host>
+export embulk_proxy_port=<Your-Proxy-Port>
+embulk run config.yml
+```

--- a/src/main/java/org/embulk/input/marketo/rest/MarketoBaseRestClient.java
+++ b/src/main/java/org/embulk/input/marketo/rest/MarketoBaseRestClient.java
@@ -321,7 +321,7 @@ public class MarketoBaseRestClient implements AutoCloseable
         if (Objects.isNull(System.getenv("embulk_proxy_host"))) {
             return false;
         }
-        if (Objects.isNull(System.getenv( "embulk_proxy_port"))) {
+        if (Objects.isNull(System.getenv("embulk_proxy_port"))) {
             return false;
         }
         return true;
@@ -337,8 +337,8 @@ public class MarketoBaseRestClient implements AutoCloseable
         return Integer.parseInt(System.getenv("embulk_proxy_port"));
     }
 
-    private HttpProxy getProxy(){
+    private HttpProxy getProxy()
+    {
         return new HttpProxy(getProxyHost(), getProxyPort());
     }
-
 }


### PR DESCRIPTION
### Are all connections created by the plugin secure?

- [x] Does it opt secure communication standard? Such as HTTPS, SSH, SFTP, SMTP STARTTLS. If not check with CISO to decide we can deploy the plugin.
- [x] Does support both authentication and encryption appropriately? Such as: "just encrypting without authentication" that is insecure.

### Does the plugin connect only to its expected external site which the customer explicitly set in their config file?

- [x] Does NOT connect unexpected external site and our internal endpoints? Such as: “v3/job/:id/set_started” callback endpoint.

### Does NOT the plugin persist any customers' private information? Identify the private information beforehand.

- [x] Does NOT include them in (temporary) files?
- [x] Does NOT include them in log messages and exception messages?

### What kind of environments does the plugin interact with?

- [x] Does NOT execute any shell command?
- [x] Does NOT read any files on the running instance? Such as: "/etc/passwords". It’s ok to read temporary files that the plugin wrote.
- [x] Does use to create temporary files by spi.TempFileSpace utility to avoid the conflict of the file names.
- [x] Does NOT get environment variables or JVM system properties at runtime? Such as AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY in environment variables

### Does NOT the plugin use insecure libraries?

- [x] Line up all depending library so that we can identify the impact of security incident of those library if any.
- [x] Check libraries usage of the plugin; all security check list must apply to the library usages. Such as "Are all connections created by the library secure?"

### Does NOT the plugin source code repository contain kinds of credentials

- [x] API keys
- [x] Passwords

### Make sure to free up all resources allocated during Embulk transaction “committing” or “rolling back”or before.

- [x] Network (connections, pooled connections)
- [x] Memory (cache in static variables)
- [x] File (temporary files)
- [x] CPU (threads, processes)